### PR TITLE
Documentation: Add SlimeChild PolySeq to list of supporting modules

### DIFF
--- a/docs/clipboard-format.md
+++ b/docs/clipboard-format.md
@@ -116,3 +116,5 @@ json_t* Note::toInteropJson()
 **Impromptu Modular:** ChordKey, Foundry, FourView, PhraseSeq16/32, SMS16, and BigButtonSeq2.
 
 **SquinkyLabs:** Seq++.
+
+**Slime Child Audio:** Substation PolySequencer


### PR DESCRIPTION
This request adds Slime Child Audio's _PolySequencer_ module to the list of modules that support the Portable Sequence clipboard format.